### PR TITLE
Update README and add easy Heroku integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-# slack-vote
-A voting bot created with Node, with easy deployment to Heroku
+<div align="center"><img src="http://i.imgur.com/zmvMFDO.png"/><br><br><img src="http://i.imgur.com/GU4eE21.gif"/><h4>Q: What is slack-vote?<br>A: A voting bot for Slack created with Node, with easy deployment to Heroku</h2></div><br>
 
-Slack users can now start a poll and vote in a slack channel, using the Slack API, specifically Outgoing Integrations. Users are able to enter these commands in the room:
+With slack-vote, slack users can now start a poll and vote in a slack channel. Using the Slack API's Outgoing Integrations, users are able to enter these commands in the room:
 ```
 start poll What's for Lunch?
 ```
@@ -13,8 +12,6 @@ If there is not already a vote for Pizza, a new option for Pizza is created. If 
 
 The bot will then respond with the results of the vote so far:
 ```
-vote-bot    2:49pm
-
 Current Poll: What's for Lunch?
 Results:
 Chinese: 5
@@ -29,41 +26,19 @@ close poll
 ```
 
 ---
-## Developer Documentation
+# Setup
 
-To run this in terminal:
-```
-redis-server
-export NODE_ENV=development
-node server.js
-```
-After the first run, you can simply run
-```
-node server.js
-```
+Getting slack-vote to work properly depends on two key components: the slack integrations and the back-end server. Using Heroku for the back-end is free, reliable, and easy.
 
-
-To test this in terminal:
-```
-npm test
-```
-
-### Local Development Setup
-* Install node
-* `sudo npm install`
-* Install redis locally - instructions here http://redis.io/topics/quickstart
-* See "To run this in terminal" above
-
-## Heroku Setup
-If using Heroku, you must have a credit card on file to use [Heroku Redis](https://elements.heroku.com/addons/heroku-redis) (the most basic usage plan is free). 
+### Heroku Setup
+Note: You must have a credit card on file to use [Heroku Redis](https://elements.heroku.com/addons/heroku-redis) (the most basic usage plan is free). 
 
 * Create a new Heroku app
 * Add the free [Heroku Redis add-on](https://elements.heroku.com/addons/heroku-redis) to this app
-* Comment and un-comment out the appropriate lines in `persist.js` (see line 12) for Heroku Redis to operate
 * Deploy to heroku
 * If the server is running properly, when you visit the address with a browser, it should say `Alive and well.` in plain text.
 
-## Slack Integration
+### Slack Integration
 Once the server is up and running, you need to add to your organization's custom integrations. These can be found at https://my.slack.com/apps/manage/custom-integrations 
 
 You'll need to add three outgoing webhook configurations:
@@ -80,3 +55,26 @@ That's it! You should now have the voting system up and running!
 
 Note: You can customize the server's JSON responses to include slack text formatting such as `*bold*` and `_italics_` as well as any custom animated emojis your organization might have. Slack will parse the server text response as a normal slack text entry.
 
+##If you don't plan on using Heroku
+
+* Comment out and un-comment the appropriate lines in `persist.js` (see line 12)
+* Install Node.js: https://nodejs.org/en/download/
+* In the terminal, run `sudo npm install`
+* Install Redis: http://redis.io/topics/quickstart
+* You should be ready to run this directly from the terminal
+
+To run this from a terminal for the first time:
+```
+redis-server
+export NODE_ENV=development
+node server.js
+```
+After that first run, you can simply run
+```
+node server.js
+```
+
+To test this in terminal:
+```
+npm test
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"><img src="http://i.imgur.com/zmvMFDO.png"/><br><br><img src="http://i.imgur.com/GU4eE21.gif"/></div><h4>Q: What is slack-vote?<br>A: A voting bot for Slack created with Node, with easy deployment to Heroku</h2><br><br>
+<div align="center"><img src="http://i.imgur.com/zmvMFDO.png"/><br><br><img src="http://i.imgur.com/GU4eE21.gif"/></div><h4>Q: What is slack-vote?<br>A: A voting bot for Slack created with Node, with easy deployment to Heroku</h2><br>
 
 With slack-vote, slack users can now start a poll and vote in a slack channel. Using the Slack API's Outgoing Integrations, users are able to enter these commands in the room:
 ```
@@ -28,15 +28,15 @@ close poll
 ---
 # Setup
 
-Getting slack-vote to work properly depends on two key components: the slack integrations and the back-end server. Using Heroku for the back-end is free, reliable, and easy.
+Getting slack-vote to work properly depends on two key components: the slack integrations and the back-end server. Using Heroku for the back-end is free, reliable, and easy to setup.
 
 ### Heroku Setup
-Note: You must have a credit card on file to use [Heroku Redis](https://elements.heroku.com/addons/heroku-redis) (the most basic usage plan is free). 
+Note: You *must* have a credit card on file to use [Heroku Redis](https://elements.heroku.com/addons/heroku-redis) (the most basic usage plan is free). 
 
 * Create a new Heroku app
 * Add the free [Heroku Redis add-on](https://elements.heroku.com/addons/heroku-redis) to this app
-* Deploy to heroku
-* If the server is running properly, when you visit the address with a browser, it should say `Alive and well.` in plain text.
+* Deploy the code from this slack-vote repo to Heroku
+* If the server is running properly, when you visit the address with a browser it should say `Alive and well.` in plain text.
 
 ### Slack Integration
 Once the server is up and running, you need to add to your organization's custom integrations. These can be found at https://my.slack.com/apps/manage/custom-integrations 
@@ -50,6 +50,8 @@ For each of these webhooks, you'll need to add a trigger word. The above usage e
 * start poll
 * vote
 * close poll
+
+You'll also have to choose your own image and bot name to appear when the server responses are published in your Slack channels. For consistency's sake, it makes sense to use the same image and bot name for each of the three webhook configurations.
 
 That's it! You should now have the voting system up and running!
 
@@ -69,7 +71,7 @@ redis-server
 export NODE_ENV=development
 node server.js
 ```
-After that first run, you can simply run
+After that first run, you can simply type:
 ```
 node server.js
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"><img src="http://i.imgur.com/zmvMFDO.png"/><br><br><img src="http://i.imgur.com/GU4eE21.gif"/></div><h4>Q: What is slack-vote?<br>A: A voting bot for Slack created with Node, with easy deployment to Heroku</h2><br>
+<div align="center"><img src="http://i.imgur.com/zmvMFDO.png"/><br><br><img src="http://i.imgur.com/GU4eE21.gif"/></div><h4>Q: What is slack-vote?<br>A: A voting bot for <a href='http://www.slack.com'>Slack</a> created with <a href="http://www.nodejs.org">Node</a> and <a href="http://expressjs.com/">Express</a>, with easy deployment to <a href="http://www.heroku.com">Heroku</a></h2><br>
 
 With slack-vote, slack users can now start a poll and vote in a slack channel. Using the Slack API's Outgoing Integrations, users are able to enter these commands in the room:
 ```
@@ -25,10 +25,12 @@ At the end of the voting session, someone is able to close the poll by entering 
 close poll
 ```
 
+*The server treats every Slack channel separately, so you can have concurrent polls on different subjects in multiple Slack channels.*
+
 ---
 # Setup
 
-Getting slack-vote to work properly depends on two key components: the slack integrations and the back-end server. Using Heroku for the back-end is free, reliable, and easy to setup.
+Getting slack-vote to work properly depends on two key components: the Slack integrations and the back-end server. Using Heroku for the back-end is free, reliable, and easy to setup.
 
 ### Heroku Setup
 Note: You *must* have a credit card on file to use [Heroku Redis](https://elements.heroku.com/addons/heroku-redis) (the most basic usage plan is free). 
@@ -55,7 +57,7 @@ You'll also have to choose your own image and bot name to appear when the server
 
 That's it! You should now have the voting system up and running!
 
-Note: You can customize the server's JSON responses to include slack text formatting such as `*bold*` and `_italics_` as well as any custom animated emojis your organization might have. Slack will parse the server text response as a normal slack text entry.
+Note: You can customize the server's JSON responses to include Slack text formatting such as `*bold*` and `_italics_` as well as any custom animated emojis your organization might have. Slack will parse the server text response as a normal Slack text entry.
 
 ##If you don't plan on using Heroku
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Getting slack-vote to work properly depends on two key components: the slack int
 ### Heroku Setup
 Note: You *must* have a credit card on file to use [Heroku Redis](https://elements.heroku.com/addons/heroku-redis) (the most basic usage plan is free). 
 
-* Create a new Heroku app
+* Create a [new Heroku app](https://dashboard.heroku.com/new)
 * Add the free [Heroku Redis add-on](https://elements.heroku.com/addons/heroku-redis) to this app
 * Deploy the code from this slack-vote repo to Heroku
 * If the server is running properly, when you visit the address with a browser it should say `Alive and well.` in plain text.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"><img src="http://i.imgur.com/zmvMFDO.png"/><br><br><img src="http://i.imgur.com/GU4eE21.gif"/><h4>Q: What is slack-vote?<br>A: A voting bot for Slack created with Node, with easy deployment to Heroku</h2></div><br>
+<div align="center"><img src="http://i.imgur.com/zmvMFDO.png"/><br><br><img src="http://i.imgur.com/GU4eE21.gif"/></div><h4>Q: What is slack-vote?<br>A: A voting bot for Slack created with Node, with easy deployment to Heroku</h2><br><br>
 
 With slack-vote, slack users can now start a poll and vote in a slack channel. Using the Slack API's Outgoing Integrations, users are able to enter these commands in the room:
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # slack-vote
-A voting bot created with Node
+A voting bot created with Node, with easy deployment to Heroku
 
 Slack users can now start a poll and vote in a slack channel, using the Slack API, specifically Outgoing Integrations. Users are able to enter these commands in the room:
 ```
@@ -53,3 +53,30 @@ npm test
 * `sudo npm install`
 * Install redis locally - instructions here http://redis.io/topics/quickstart
 * See "To run this in terminal" above
+
+## Heroku Setup
+If using Heroku, you must have a credit card on file to use [Heroku Redis](https://elements.heroku.com/addons/heroku-redis) (the most basic usage plan is free). 
+
+* Create a new Heroku app
+* Add the free [Heroku Redis add-on](https://elements.heroku.com/addons/heroku-redis) to this app
+* Comment and un-comment out the appropriate lines in `persist.js` (see line 12) for Heroku Redis to operate
+* Deploy to heroku
+* If the server is running properly, when you visit the address with a browser, it should say `Alive and well.` in plain text.
+
+## Slack Integration
+Once the server is up and running, you need to add to your organization's custom integrations. These can be found at https://your-organization.slack.com/apps/manage/custom-integrations 
+
+You'll need to add three outgoing webhook configurations:
+* your-slackvote-app.herokuapp.com/start
+* your-slackvote-app.herokuapp.com/vote
+* your-slackvote-app.herokuapp.com/close
+
+For each of these webhooks, you'll need to add a trigger word. The above usage example uses these three trigger words for each of the respective webhooks:
+* start poll
+* vote
+* close poll
+
+That's it! You should now have the voting system up and running!
+
+Note: You can customize the server's JSON responses to include slack text formatting such as `*bold*` and `_italics_` as well as any custom animated emojis your organization might have. Slack will parse the server text response as a normal slack text entry.
+

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If using Heroku, you must have a credit card on file to use [Heroku Redis](https
 * If the server is running properly, when you visit the address with a browser, it should say `Alive and well.` in plain text.
 
 ## Slack Integration
-Once the server is up and running, you need to add to your organization's custom integrations. These can be found at https://your-organization.slack.com/apps/manage/custom-integrations 
+Once the server is up and running, you need to add to your organization's custom integrations. These can be found at https://my.slack.com/apps/manage/custom-integrations 
 
 You'll need to add three outgoing webhook configurations:
 * your-slackvote-app.herokuapp.com/start

--- a/app.json
+++ b/app.json
@@ -1,0 +1,10 @@
+{
+  "name": "slack-vote",
+  "scripts": {
+  },
+  "env": {
+  },
+  "addons": [
+    "heroku-redis"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "node-learning",
-  "version": "1.0.0",
-  "description": "Create something with node",
+  "name": "slack-vote",
+  "version": "0.5",
+  "description": "A voting/polling backend for Slack outgoing webhook configurations",
   "main": "server.js",
   "scripts": {
     "test": "mocha tests/index.js",
@@ -9,14 +9,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ben833/node-learning.git"
+    "url": "git+https://github.com/RF-Nelson/slack-vote.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/ben833/node-learning/issues"
+    "url": "https://github.com/RF-Nelson/slack-vote.git/issues"
   },
-  "homepage": "https://github.com/ben833/node-learning#readme",
+  "homepage": "https://github.com/RF-Nelson/slack-vote#readme",
   "dependencies": {
     "body-parser": "^1.13.1",
     "express": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-vote",
-  "version": "0.5",
+  "version": "0.5.0",
   "description": "A voting/polling backend for Slack outgoing webhook configurations",
   "main": "server.js",
   "scripts": {

--- a/persist.js
+++ b/persist.js
@@ -10,9 +10,18 @@ var redis = require('redis')
 
 /*
  * Set correct environment for redis.
+ *
+ * Lines 19-20 are for using Heroku Redis
+ * If using Heroku Redis, comment out lines 22-23 and uncomment lines 19-20
+ *
  */
+
+// if (process.env.REDIS_URL) {
+//   rtg = require('url').parse(process.env.REDIS_URL);
+
 if (process.env.REDISTOGO_URL) {
   rtg = require('url').parse(process.env.REDISTOGO_URL);
+
   client = redis.createClient(rtg.port, rtg.hostname);
   client.auth(rtg.auth.split(':')[1]);
 } else {

--- a/persist.js
+++ b/persist.js
@@ -12,15 +12,15 @@ var redis = require('redis')
  * Set correct environment for redis.
  *
  * Lines 19-20 are for using Heroku Redis
- * If using Heroku Redis, comment out lines 22-23 and uncomment lines 19-20
+ * If not using Heroku Redis, uncomment lines 22-23 and comment out lines 19-20
  *
  */
 
-// if (process.env.REDIS_URL) {
-//   rtg = require('url').parse(process.env.REDIS_URL);
+ if (process.env.REDIS_URL) {
+   rtg = require('url').parse(process.env.REDIS_URL);
 
-if (process.env.REDISTOGO_URL) {
-  rtg = require('url').parse(process.env.REDISTOGO_URL);
+// if (process.env.REDISTOGO_URL) {
+//  rtg = require('url').parse(process.env.REDISTOGO_URL);
 
   client = redis.createClient(rtg.port, rtg.hostname);
   client.auth(rtg.auth.split(':')[1]);


### PR DESCRIPTION
I expect many potential users will be looking to use Heroku to host slack-vote because it's free and easy to setup for something like this.

I added some commented-out code in persist.js that will need to be activated if a user wants to use Heroku Redis.

I also fleshed out the README to include explicit instructions for setting up the outgoing webhook configurations as well as the Heroku setup.
